### PR TITLE
WIP: Player persona name

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -6,8 +6,10 @@ import {
   SteamCommentData,
   AuthorComment,
   SteamResolveVanityUrlReponse,
+  SummaryResponse,
 } from "./types/types";
 import dotenv from "dotenv";
+import { doesStringOnlyContainNumbers } from "./utils/strings";
 
 dotenv.config();
 const app = express();
@@ -17,7 +19,7 @@ app.use(cors());
  * Checks if a string containers only numbers. If it does, return it as an assumed valid steamid64.
  * If it contains any numbers, it is assumed to be a vanity url. Check if that url is associated with
  * a steamid64.
- * @param input Any string input
+ * @param input Steamid64 or vanity url
  * @returns A string in the valid steamid64 format (i.e. all numbers)
  */
 const getValidSteamId64 = async (
@@ -37,20 +39,11 @@ const getValidSteamId64 = async (
 };
 
 /**
- * Check whether a string contains only digits
- * @param stringToCheck Input string
- * @returns True if the string only consists of digits, false if any non-didget is found
- */
-const doesStringOnlyContainNumbers = (stringToCheck: string): boolean => {
-  return /^\d+$/.test(stringToCheck);
-};
-
-/**
  * Gets raw data from steam community website and strips out the comments
  * @param steamId64 SteamId64 string
  * @returns Array of comment objects with each element containing author profile url and comment
  */
-const getCommentsFromSteamId64 = async (
+const getProfileCommentsFromSteamId64 = async (
   steamId64: string
 ): Promise<AuthorComment[] | null> => {
   // kennyS steamID64: 76561198024905796
@@ -92,9 +85,54 @@ const getCommentsFromSteamId64 = async (
       }
     });
 
+    // get unique author steamid64s
+    // const uniqueAuthorSteamid64s = commentPairs
+    //   .map((c) => c.authorUrl)
+    //   .filter((value, index, self) => self.indexOf(value) === index)
+    //   .map(async (url) => await getValidSteamId64(url));
+
     return commentPairs;
   }
 };
+
+/**
+ * Match up steamid64s with their corresponding persona name
+ * @param steamId64s List of steamid64s (max 100)
+ * @returns Map of steamId64 to persona name
+ */
+const getPersonaNameFromSteamId64 = async (steamId64s: string[]) => {
+  let formattedString = "[";
+  steamId64s.forEach((id, index) => {
+    formattedString += `${id}${index !== steamId64s.length - 1 ? "," : ""}`;
+  });
+  formattedString += "]";
+
+  const url = `https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v2/?key=${process.env.STEAM_API_KEY}&format=json&steamids=${formattedString}`;
+  const res = await fetch(url);
+  const json = (await res.json()) as SummaryResponse;
+
+  const steamId64PersonaNameMap = new Map<string, string>();
+
+  json.response.players.forEach((player) => {
+    steamId64PersonaNameMap.set(player.steamid, player.personaname ?? "");
+  });
+
+  return steamId64PersonaNameMap;
+};
+
+app.get("/test", async (req, res) => {
+  // res.send(
+  //   await getPersonaNameFromSteamId64([
+  //     "76561198308003066",
+  //     "76561197984864068",
+  //   ])
+  // );
+  // await getPersonaNameFromSteamId64(["76561198308003066", "76561197984864068"]);
+  // await getPeronaNameFromUrl("https://steamcommunity.com/id/jebus123");
+  // res.send(
+  //   await getPeronaNameFromUrl("https://steamcommunity.com/id/jebus123")
+  // );
+});
 
 app.get("/comments/:steamId", async (req, res) => {
   const steamId64 = await getValidSteamId64(req.params.steamId);
@@ -105,7 +143,7 @@ app.get("/comments/:steamId", async (req, res) => {
     return;
   }
 
-  const comments = await getCommentsFromSteamId64(steamId64);
+  const comments = await getProfileCommentsFromSteamId64(steamId64);
 
   if (!comments) {
     res.statusMessage = "No comments found";

--- a/backend/src/types/types.ts
+++ b/backend/src/types/types.ts
@@ -13,6 +13,8 @@ export interface SteamCommentData {
 export interface AuthorComment {
   authorUrl: string;
   authorComment: string;
+  personaName: string;
+  avatarSrc: string;
 }
 
 interface SteamResolveVanityUrlData {
@@ -22,31 +24,4 @@ interface SteamResolveVanityUrlData {
 }
 export interface SteamResolveVanityUrlReponse {
   response: SteamResolveVanityUrlData;
-}
-
-interface PlayerSummary {
-  steamid: string;
-  communityvisibilitystate: number | null;
-  profilestate: number | null;
-  personaname: string | null;
-  commentpermission: number | null;
-  profileurl: string | null;
-  avatar: string | null;
-  avatarmedium: string | null;
-  avatarfull: string | null;
-  avatarhash: string | null;
-  personastate: number | null;
-  primaryclanid: string | null;
-  timecreated: number | null;
-  personastateflags: 0 | null;
-  loccountrycode: string | null;
-  locstatecode: string | null;
-}
-
-interface PlayerSummaries {
-  players: PlayerSummary[];
-}
-
-export interface SummaryResponse {
-  response: PlayerSummaries;
 }

--- a/backend/src/types/types.ts
+++ b/backend/src/types/types.ts
@@ -23,3 +23,30 @@ interface SteamResolveVanityUrlData {
 export interface SteamResolveVanityUrlReponse {
   response: SteamResolveVanityUrlData;
 }
+
+interface PlayerSummary {
+  steamid: string;
+  communityvisibilitystate: number | null;
+  profilestate: number | null;
+  personaname: string | null;
+  commentpermission: number | null;
+  profileurl: string | null;
+  avatar: string | null;
+  avatarmedium: string | null;
+  avatarfull: string | null;
+  avatarhash: string | null;
+  personastate: number | null;
+  primaryclanid: string | null;
+  timecreated: number | null;
+  personastateflags: 0 | null;
+  loccountrycode: string | null;
+  locstatecode: string | null;
+}
+
+interface PlayerSummaries {
+  players: PlayerSummary[];
+}
+
+export interface SummaryResponse {
+  response: PlayerSummaries;
+}

--- a/backend/src/utils/strings.ts
+++ b/backend/src/utils/strings.ts
@@ -1,0 +1,10 @@
+/**
+ * Check whether a string contains only digits
+ * @param stringToCheck Input string
+ * @returns True if the string only consists of digits, false if any non-didget is found
+ */
+export const doesStringOnlyContainNumbers = (
+  stringToCheck: string
+): boolean => {
+  return /^\d+$/.test(stringToCheck);
+};

--- a/frontend/steam-comments/src/App.vue
+++ b/frontend/steam-comments/src/App.vue
@@ -88,8 +88,18 @@ export default defineComponent({
         return;
       }
 
+      // todo refactor to use regex
+      let filteredInput = trimmedInput.replace(
+        "https://steamcommunity.com/id/",
+        ""
+      );
+      filteredInput = filteredInput.replace(
+        "https://steamcommunity.com/profiles/",
+        ""
+      );
+
       loading.value = true;
-      comments.value = await api.getAllCommentsForUser(trimmedInput);
+      comments.value = await api.getAllCommentsForUser(filteredInput);
       loading.value = false;
     };
 

--- a/frontend/steam-comments/src/App.vue
+++ b/frontend/steam-comments/src/App.vue
@@ -41,13 +41,28 @@
             Found <b>{{ comments.length }}</b> comments.
           </v-col>
         </v-row>
-        <v-row v-for="(comment, index) in comments" :key="index">
-          <v-col cols="6">
+        <v-row
+          v-for="(comment, index) in comments"
+          :key="index"
+          :style="{
+            'background-color': rowColor(index),
+            'overflow-y': 'scroll',
+          }"
+        >
+          <v-col cols="auto">
             <a :href="comment.authorUrl" target="_blank">
-              {{ comment.authorUrl }}
+              <img :src="comment.avatarSrc" alt="Player avatar" />
             </a>
           </v-col>
-          <v-col cols="6">{{ comment.authorComment }}</v-col>
+          <v-col cols="auto">
+            <v-row>
+              <v-col cols="12">
+                <pre>{{ comment.personaName }}</pre>
+              </v-col>
+            </v-row>
+          </v-col>
+          <v-spacer />
+          <v-col cols="7">{{ comment.authorComment }}</v-col>
         </v-row>
       </v-container>
       <v-dialog v-model="loading" hide-overlay persistent width="300">
@@ -111,6 +126,11 @@ export default defineComponent({
       clearErrorMessages,
       errorMessages,
       apiErrorMessage: computed(() => errorStore.apiErrorMessage.value),
+      rowColor: (rowIndex: number) => {
+        return rowIndex % 2 !== 0 ? "white" : "#b0ceff";
+      },
+      defaultAvatarSrc:
+        "https://cdn.cloudflare.steamstatic.com/steamcommunity/public/images/avatars/48/4888d158c81bc8f1d7644321d9eb78b0048a9bda_medium.jpg",
     };
   },
 });


### PR DESCRIPTION
When we request comments, we are given a mixture of account URLs containing either a `steamid64` in the form of `/profiles/<steamid64>` or a `vanity url` in the form of `/id/<vanity url>`. In order to display persona name, I need to:
 - filter for `<bdi>` tag in each thread.

Profile pictures can also be taken from the comment thread too.